### PR TITLE
Fix map panning in Firefox and Edge

### DIFF
--- a/osgidashboard-dashboard/src/main/java/org/vaadin/mmerruko/griddashboard/ui/GridDashboard.java
+++ b/osgidashboard-dashboard/src/main/java/org/vaadin/mmerruko/griddashboard/ui/GridDashboard.java
@@ -9,6 +9,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.vaadin.ui.JavaScript;
 import org.vaadin.mmerruko.griddashboard.IWidgetRegistry;
 import org.vaadin.mmerruko.griddashboard.WidgetStatusListener;
 import org.vaadin.mmerruko.griddashboard.model.GridDashboardModel;
@@ -161,7 +162,15 @@ public class GridDashboard extends GridLayout implements WidgetStatusListener {
             componentToWidget.remove(widget);
             fillWithPlaceholders();
         });
-        
+        // Prevents map panning (canvas mousedown) from triggering grid drag
+        JavaScript.getCurrent().execute(
+                "if(window.wDragStop===undefined) window.wDragStop = " +
+                        "ev => ev.currentTarget.draggable = ev.target.tagName." +
+                        "toLowerCase() !== 'canvas';" +
+                        "Array.prototype.forEach.call(document.querySelectorAll" +
+                        "('.dashboard-widget'), el => el.addEventListener" +
+                        "('mousedown', window.wDragStop));");
+
         configureInternalDashboardDnd(widget, widgetFrame);
         return widgetFrame;
     }


### PR DESCRIPTION
This is actually a bit tricky. The map uses `mousedown` for panning. This also triggers a `drag` on the grid slot in Firefox and Edge.

The problem and solutions in a jsfiddle:
https://jsfiddle.net/Lo0rs5un/4/

It would be difficult to even modify the OLMap client-side code. In addition, as it is not `draggable`, it will not receive `drag` events and thus can not stop them from propagating.

This solution listens to `mousedown` on the widget container. If the `target` is the map canvas element, it temporarily disables its draggable property until next `mousedown`. 